### PR TITLE
Update to 0..9.6.4

### DIFF
--- a/DLLCopyList.txt
+++ b/DLLCopyList.txt
@@ -11,3 +11,4 @@ Nito.Collections.Deque.dll
 Nito.Disposables.dll
 System.Threading.Timer.dll
 System.Threading.Tasks.Extensions.dll
+Newtonsoft.Json.dll

--- a/DiscordLink/Commands/DiscordCommands.cs
+++ b/DiscordLink/Commands/DiscordCommands.cs
@@ -67,18 +67,18 @@ namespace Eco.Plugins.DiscordLink
                 if (stringParts.Count <= 1 && embedParts.Count <= 1)
                 {
                     DiscordEmbed embed = (embedParts.Count >= 1) ? embedParts.First() : null;
-                    await ctx.RespondAsync(textContent, isTTS: false, embed);
+                    await ctx.RespondAsync(textContent, embed);
                 }
                 else
                 {
                     // Either make sure we have permission to use embeds or convert the embed to text
                     foreach (string textMessagePart in stringParts)
                     {
-                        await ctx.RespondAsync(textMessagePart, isTTS: false, null);
+                        await ctx.RespondAsync(textMessagePart, null);
                     }
                     foreach (DiscordEmbed embedPart in embedParts)
                     {
-                        await ctx.RespondAsync(null, isTTS: false, embedPart);
+                        await ctx.RespondAsync(null, embedPart);
                     }
                 }
             }

--- a/DiscordLink/DiscordLink.cs
+++ b/DiscordLink/DiscordLink.cs
@@ -506,6 +506,11 @@ namespace Eco.Plugins.DiscordLink
 
             UpdateModules(DLEventType.DiscordMessage, message);
         }
+
+        public Task ShutdownAsync()
+        {
+            throw new NotImplementedException();
+        }
         #endregion
     }
 }

--- a/DiscordLink/DiscordLink.csproj
+++ b/DiscordLink/DiscordLink.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+	<TargetFrameworks>net5.0</TargetFrameworks>
     <PackageLicenseExpression>Gnu Affero</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Eco-DiscordLink/EcoDiscordPlugin</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Eco-DiscordLink/EcoDiscordPlugin</RepositoryUrl>
@@ -25,13 +25,14 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.0.0-rc1" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-rc1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0-rc.2.20475.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-rc.2.20475.5" />
-    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.9" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
+    <PackageReference Include="DSharpPlus" Version="4.2.0" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.24" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DiscordLink/Modules/Displays/WorkPartyDisplay.cs
+++ b/DiscordLink/Modules/Displays/WorkPartyDisplay.cs
@@ -72,10 +72,10 @@ namespace Eco.Plugins.DiscordLink.Modules
                     {
                         case LaborWork laborWork:
                             {
-                                if (!string.IsNullOrEmpty(laborWork.ShortDescriptionRemainingWork))
+                                if (!string.IsNullOrEmpty(laborWork.ShortDescriptionRemaining))
                                 {
                                     workType = $"Labor for {laborWork.Order.Recipe.RecipeName}";
-                                    workEntries.Add(MessageUtil.StripTags(laborWork.ShortDescriptionRemainingWork));
+                                    workEntries.Add(MessageUtil.StripTags(laborWork.ShortDescriptionRemaining));
                                 }
                                 break;
                             }

--- a/DiscordLink/Utilities/DiscordUtil.cs
+++ b/DiscordLink/Utilities/DiscordUtil.cs
@@ -45,17 +45,17 @@ namespace Eco.Plugins.DiscordLink.Utilities
                 if(stringParts.Count <= 1 && embedParts.Count <= 1)
                 {
                     DiscordEmbed embed = (embedParts.Count >= 1) ? embedParts.First() : null;
-                    await channel.SendMessageAsync(fullTextContent, tts: false, embed);
+                    await channel.SendMessageAsync(fullTextContent, embed);
                 }
                 else
                 {
                     foreach (string textMessagePart in stringParts)
                     {
-                        await channel.SendMessageAsync(textMessagePart, tts: false, null);
+                        await channel.SendMessageAsync(textMessagePart, null);
                     }
                     foreach(DiscordEmbed embedPart in embedParts)
                     {
-                        await channel.SendMessageAsync(null, tts: false, embedPart);
+                        await channel.SendMessageAsync(null, embedPart);
                     }
                 }
             }
@@ -80,17 +80,17 @@ namespace Eco.Plugins.DiscordLink.Utilities
                 if (stringParts.Count <= 1 && embedParts.Count <= 1)
                 {
                     DiscordEmbed embed = (embedParts.Count >= 1) ? embedParts.First() : null;
-                    await targetMember.SendMessageAsync(textContent, is_tts: false, embed);
+                    await targetMember.SendMessageAsync(textContent, embed);
                 }
                 else
                 {
                     foreach (string textMessagePart in stringParts)
                     {
-                        await targetMember.SendMessageAsync(textMessagePart, is_tts: false, null);
+                        await targetMember.SendMessageAsync(textMessagePart, null);
                     }
                     foreach (DiscordEmbed embedPart in embedParts)
                     {
-                        await targetMember.SendMessageAsync(null, is_tts: false, embedPart);
+                        await targetMember.SendMessageAsync(null, embedPart);
                     }
                 }
             }

--- a/DiscordLink/Utilities/EcoUtil.cs
+++ b/DiscordLink/Utilities/EcoUtil.cs
@@ -22,12 +22,12 @@ namespace Eco.Plugins.DiscordLink.Utilities
 
         public static void SendPopupMessage(string message, User user = null)
         {
-            SendMessageOfType(null, message, ChatBase.MessageType.Popup, user);
+            SendMessageOfType(null, message, ChatBase.MessageType.InfoPanel, user);
         }
 
         public static void SendAnnouncementMessage(string title, string message, User user = null)
         {
-            SendMessageOfType(title, message, ChatBase.MessageType.Announcement, user);
+            SendMessageOfType(title, message, ChatBase.MessageType.GlobalAnnoucement, user);
         }
 
         private static void SendMessageOfType(string title, string message, ChatBase.MessageType messageType, User user )
@@ -36,7 +36,7 @@ namespace Eco.Plugins.DiscordLink.Utilities
             {
                 case ChatBase.MessageType.Temporary:
                 case ChatBase.MessageType.Permanent:
-                case ChatBase.MessageType.Popup:
+                case ChatBase.MessageType.InfoPanel:
                     if (user == null)
                     {
                         ChatBase.Send(new ChatBase.Message(message, messageType));
@@ -47,7 +47,7 @@ namespace Eco.Plugins.DiscordLink.Utilities
                     }
                     break;
 
-                case ChatBase.MessageType.Announcement:
+                case ChatBase.MessageType.GlobalAnnoucement:
                     if (user == null)
                     {
                         ChatBase.Send(new ChatBase.Message(title, message));


### PR DESCRIPTION
Update of all dependencies and related code changes to work with Eco 0.9.4.6

- Updated D#+ to 4.2.0
- Updated DiscordCommands to no longer set isTTL when creating commands ( in D#+ 4.2.0 )
- Updated WorkPartyDisplay due to Eco API changes
- Updated Ecoutil due to Eco API changes
- Updated projectfile to use net5.0 ( require for Eco 9.4 )
- Updated dependencies to match the required net5.0
- Added Newtonsoft.Json to the DDLs to be copied as it is no longer bundled