### PR TITLE
Add Basic WebAPI support

### DIFF
--- a/DiscordLink/DiscordLink.csproj
+++ b/DiscordLink/DiscordLink.csproj
@@ -82,15 +82,15 @@
       <HintPath Condition="Exists('..\..\Eco\Server\Eco.Simulation\bin\Release\net7.0-windows\Eco.Simulation.dll')">..\..\Eco\Server\Eco.Simulation\bin\Release\net7.0-windows\Eco.Simulation.dll</HintPath>
       <Private>false</Private>
     </Reference>
-	  <Reference Include="Eco.WorldGenerator">
-		  <HintPath Condition="Exists('..\Dependencies\Eco.WorldGenerator.dll')">..\Dependencies\Eco.WorldGenerator.dll</HintPath>
-		  <HintPath Condition="Exists('..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll')">..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll</HintPath>
-	  </Reference>
-	  <Reference Include="Eco.WebServer">
-		  <HintPath Condition="Exists('..\Dependencies\Eco.WebServer.dll')">..\Dependencies\Eco.WebServer.dll</HintPath>
-		  <HintPath Condition="Exists('..\..\Eco\Server\Eco.WebServer\bin\Release\net7.0-windows\Eco.WebServer.dll')">..\..\Eco\Server\Eco.WebServer\bin\Release\net7.0-windows\Eco.WebServer.dll</HintPath>
-		  <Private>False</Private>
-	  </Reference>
+	<Reference Include="Eco.WorldGenerator">
+	 <HintPath Condition="Exists('..\Dependencies\Eco.WorldGenerator.dll')">..\Dependencies\Eco.WorldGenerator.dll</HintPath>
+	 <HintPath Condition="Exists('..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll')">..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll</HintPath>
+	</Reference>
+	<Reference Include="Eco.WebServer">
+	 <HintPath Condition="Exists('..\Dependencies\Eco.WebServer.dll')">..\Dependencies\Eco.WebServer.dll</HintPath>
+	 <HintPath Condition="Exists('..\..\Eco\Server\Eco.WebServer\bin\Release\net7.0-windows\Eco.WebServer.dll')">..\..\Eco\Server\Eco.WebServer\bin\Release\net7.0-windows\Eco.WebServer.dll</HintPath>
+	 <Private>False</Private>
+	</Reference>
 	  
   </ItemGroup>
   

--- a/DiscordLink/DiscordLink.csproj
+++ b/DiscordLink/DiscordLink.csproj
@@ -26,9 +26,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.8" />
     <PackageReference Include="NetFabric.Hyperlinq.Abstractions" Version="1.3.0" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="4.13.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.3.1" />
   </ItemGroup>
 
   <!-- Use project references if the projects are installed and package references otherwise -->
@@ -83,13 +80,14 @@
       <Private>false</Private>
     </Reference>
 	<Reference Include="Eco.WorldGenerator">
-	 <HintPath Condition="Exists('..\Dependencies\Eco.WorldGenerator.dll')">..\Dependencies\Eco.WorldGenerator.dll</HintPath>
-	 <HintPath Condition="Exists('..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll')">..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll</HintPath>
+	  <HintPath Condition="Exists('..\Dependencies\Eco.WorldGenerator.dll')">..\Dependencies\Eco.WorldGenerator.dll</HintPath>
+	  <HintPath Condition="Exists('..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll')">..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll</HintPath>
+	  <Private>false</Private>
 	</Reference>
 	<Reference Include="Eco.WebServer">
-	 <HintPath Condition="Exists('..\Dependencies\Eco.WebServer.dll')">..\Dependencies\Eco.WebServer.dll</HintPath>
-	 <HintPath Condition="Exists('..\..\Eco\Server\Eco.WebServer\bin\Release\net7.0-windows\Eco.WebServer.dll')">..\..\Eco\Server\Eco.WebServer\bin\Release\net7.0-windows\Eco.WebServer.dll</HintPath>
-	 <Private>False</Private>
+	  <HintPath Condition="Exists('..\Dependencies\Eco.WebServer.dll')">..\Dependencies\Eco.WebServer.dll</HintPath>
+	  <HintPath Condition="Exists('..\..\Eco\Server\Eco.WebServer\bin\Release\net7.0-windows\Eco.WebServer.dll')">..\..\Eco\Server\Eco.WebServer\bin\Release\net7.0-windows\Eco.WebServer.dll</HintPath>
+	 <Private>false</Private>
 	</Reference>
 	  
   </ItemGroup>

--- a/DiscordLink/DiscordLink.csproj
+++ b/DiscordLink/DiscordLink.csproj
@@ -23,8 +23,12 @@
 
   <ItemGroup>
     <PackageReference Include="ConcurrentHashSet" Version="1.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.8" />
     <PackageReference Include="NetFabric.Hyperlinq.Abstractions" Version="1.3.0" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.13.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.3.1" />
   </ItemGroup>
 
   <!-- Use project references if the projects are installed and package references otherwise -->
@@ -78,10 +82,16 @@
       <HintPath Condition="Exists('..\..\Eco\Server\Eco.Simulation\bin\Release\net7.0-windows\Eco.Simulation.dll')">..\..\Eco\Server\Eco.Simulation\bin\Release\net7.0-windows\Eco.Simulation.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Eco.WorldGenerator">
-      <HintPath Condition="Exists('..\Dependencies\Eco.WorldGenerator.dll')">..\Dependencies\Eco.WorldGenerator.dll</HintPath>
-      <HintPath Condition="Exists('..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll')">..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll</HintPath>
-    </Reference>
+	  <Reference Include="Eco.WorldGenerator">
+		  <HintPath Condition="Exists('..\Dependencies\Eco.WorldGenerator.dll')">..\Dependencies\Eco.WorldGenerator.dll</HintPath>
+		  <HintPath Condition="Exists('..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll')">..\..\Eco\Server\Eco.WorldGenerator\bin\Release\net7.0-windows\Eco.WorldGenerator.dll</HintPath>
+	  </Reference>
+	  <Reference Include="Eco.WebServer">
+		  <HintPath Condition="Exists('..\Dependencies\Eco.WebServer.dll')">..\Dependencies\Eco.WebServer.dll</HintPath>
+		  <HintPath Condition="Exists('..\..\Eco\Server\Eco.WebServer\bin\Release\net7.0-windows\Eco.WebServer.dll')">..\..\Eco\Server\Eco.WebServer\bin\Release\net7.0-windows\Eco.WebServer.dll</HintPath>
+		  <Private>False</Private>
+	  </Reference>
+	  
   </ItemGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/DiscordLink/Source/Commands/SharedCommands.cs
+++ b/DiscordLink/Source/Commands/SharedCommands.cs
@@ -75,7 +75,7 @@ namespace Eco.Plugins.DiscordLink
         {
             if (DiscordLink.Obj.Client.ConnectionStatus != DLDiscordClient.ConnectionState.Connected)
             {
-                await ReportCommandError(source, callContext, "Failed to force update - Disoord client not connected");
+                await ReportCommandError(source, callContext, "Failed to force update - Discord client not connected");
                 return false;
             }
 

--- a/DiscordLink/Source/Commands/SharedCommands.cs
+++ b/DiscordLink/Source/Commands/SharedCommands.cs
@@ -33,7 +33,9 @@ namespace Eco.Plugins.DiscordLink
             [ChoiceName("Eco")]
             Eco,
             [ChoiceName("Discord")]
-            Discord
+            Discord,
+            [ChoiceName("WebCommand")]
+            WebCommand
         }
 
 
@@ -41,7 +43,7 @@ namespace Eco.Plugins.DiscordLink
         {
             if (source == CommandInterface.Eco)
                 EcoCommands.ReportCommandError(callContext as User, message);
-            else
+            else if (source == CommandInterface.Discord)
                 await DiscordCommands.ReportCommandError(callContext as InteractionContext, message);
         }
 
@@ -49,7 +51,7 @@ namespace Eco.Plugins.DiscordLink
         {
             if (source == CommandInterface.Eco)
                 EcoCommands.ReportCommandInfo(callContext as User, message);
-            else
+            else if (source == CommandInterface.Discord)
                 await DiscordCommands.ReportCommandInfo(callContext as InteractionContext, message);
         }
 

--- a/DiscordLink/Source/WebApi/V1/DiscordLinkController.cs
+++ b/DiscordLink/Source/WebApi/V1/DiscordLinkController.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Eco.WebServer.Web.Authorization;
+using Eco.Shared;
+using Eco.Shared.Utils;
+using DiscordLink.Source.WebApi.V1.Models;
+
+namespace Eco.Plugins.DiscordLink
+{
+    /// <summary>MVC <seealso cref="Controller"/> instance for accessing and interacting with DiscordLink.</summary>
+    [Route("discordlink/api/v1")]
+    [Authorize(Policy = PolicyNames.RequireAdmin)]
+    public class DiscordLinkController : Controller
+    {
+
+        /// <summary>Force restart DiscordLink</summary>
+        [HttpPost("restart")]
+        public async Task<bool> PostReloadPlugin()
+        {
+            return await SharedCommands.RestartPlugin(SharedCommands.CommandInterface.WebCommand, null);
+        }
+
+        /// <summary>Post an Invite to the discord server.</summary>
+        [HttpPost("/chat/invite")]
+        public async Task<bool> PostInviteMessage()
+        {
+            bool sent = await SharedCommands.PostInviteMessage(SharedCommands.CommandInterface.WebCommand, null);
+            Response.StatusCode = sent ? 201 : 500;
+            return sent;
+        }
+
+        /// <summary>Get the status of Discordlink.</summary>
+        [HttpGet("status/plugin")]
+        public DiscordLinkPluginStatusV1 GetPluginStatus()
+        {
+            DiscordLink plugin = DiscordLink.Obj;
+            DLDiscordClient client = plugin.Client;
+            return new DiscordLinkPluginStatusV1
+            {
+                DiscordStatus = client.Status,
+                PluginStatus = plugin.GetStatus(),
+                ServerVersion = EcoVersion.VersionNumber,
+                PluginVersion = plugin.PluginVersion.ToString(),
+                LinkedUsers = DLStorage.PersistentData.LinkedUsers.Count,
+                OptInUsers = DLStorage.PersistentData.OptedInUsers.Count,
+                OptOutUsers = DLStorage.PersistentData.OptedOutUsers.Count,
+                ClientName = client.DiscordClient.CurrentUser.Username
+            };
+        }
+
+        /// <summary>Get the status of the current Configuration.</summary>
+        [HttpGet("status/config")]
+        public DiscordLinkConfigStatusV1 GetConfigValidationStatus()
+        {
+
+            DLConfigData config = DLConfig.Data;
+            List<ChannelLinkStatusV1> channelLinks = new();
+
+            if (DiscordLink.Obj.Client.ConnectionStatus == DLDiscordClient.ConnectionState.Connected)
+            {
+                // Discord guild and channel information isn't available the first time this function is called
+                if (DiscordLink.Obj.Client.Guild != null && DLConfig.GetChannelLinks(verifiedLinksOnly: false).Count > 0)
+                {
+                    foreach (ChannelLink link in DLConfig.GetChannelLinks(verifiedLinksOnly: false))
+                    {
+                        channelLinks.Add(new ChannelLinkStatusV1
+                        {
+                            Id = link.DiscordChannelId.ToString(),
+                            Valid = link.IsValid()
+                        });
+                    }
+                }
+            }
+            return new DiscordLinkConfigStatusV1
+            {
+                ClientConnected = DiscordLink.Obj.Client.ConnectionStatus == DLDiscordClient.ConnectionState.Connected,
+                BotToken = !string.IsNullOrWhiteSpace(config.BotToken),
+                InviteMessage = !(!string.IsNullOrWhiteSpace(config.InviteMessage) && !config.InviteMessage.ContainsCaseInsensitive(DLConstants.INVITE_COMMAND_TOKEN)),
+                ServerId = config.DiscordServerID != 0,
+                ChannelLinks = channelLinks
+            };
+        }
+    }
+}

--- a/DiscordLink/Source/WebApi/V1/DiscordLinkController.cs
+++ b/DiscordLink/Source/WebApi/V1/DiscordLinkController.cs
@@ -43,9 +43,6 @@ namespace Eco.Plugins.DiscordLink
                 PluginStatus = plugin.GetStatus(),
                 ServerVersion = EcoVersion.VersionNumber,
                 PluginVersion = plugin.PluginVersion.ToString(),
-                LinkedUsers = DLStorage.PersistentData.LinkedUsers.Count,
-                OptInUsers = DLStorage.PersistentData.OptedInUsers.Count,
-                OptOutUsers = DLStorage.PersistentData.OptedOutUsers.Count,
                 ClientName = client.DiscordClient.CurrentUser.Username
             };
         }

--- a/DiscordLink/Source/WebApi/V1/DiscordLinkController.cs
+++ b/DiscordLink/Source/WebApi/V1/DiscordLinkController.cs
@@ -17,6 +17,7 @@ namespace Eco.Plugins.DiscordLink
 
         /// <summary>Force restart DiscordLink</summary>
         [HttpPost("restart")]
+        [Produces("application/json")]
         public async Task<bool> PostReloadPlugin()
         {
             return await SharedCommands.RestartPlugin(SharedCommands.CommandInterface.WebCommand, null);
@@ -24,6 +25,7 @@ namespace Eco.Plugins.DiscordLink
 
         /// <summary>Post an Invite to the discord server.</summary>
         [HttpPost("chat/invite")]
+        [Produces("application/json")]
         public async Task<bool> PostInviteMessage()
         {
             bool sent = await SharedCommands.PostInviteMessage(SharedCommands.CommandInterface.WebCommand, null);
@@ -33,6 +35,7 @@ namespace Eco.Plugins.DiscordLink
 
         /// <summary>Get the status of Discordlink.</summary>
         [HttpGet("status/plugin")]
+        [Produces("application/json")]
         public DiscordLinkPluginStatusV1 GetPluginStatus()
         {
             DiscordLink plugin = DiscordLink.Obj;
@@ -49,6 +52,7 @@ namespace Eco.Plugins.DiscordLink
 
         /// <summary>Get the status of the current Configuration.</summary>
         [HttpGet("status/config")]
+        [Produces("application/json")]
         public DiscordLinkConfigStatusV1 GetConfigValidationStatus()
         {
 

--- a/DiscordLink/Source/WebApi/V1/DiscordLinkController.cs
+++ b/DiscordLink/Source/WebApi/V1/DiscordLinkController.cs
@@ -57,7 +57,7 @@ namespace Eco.Plugins.DiscordLink
         {
 
             DLConfigData config = DLConfig.Data;
-            List<ChannelLinkStatusV1> channelLinks = new();
+            List<DiscordLinkChannelStatusV1> channelLinks = new();
 
             if (DiscordLink.Obj.Client.ConnectionStatus == DLDiscordClient.ConnectionState.Connected)
             {
@@ -66,7 +66,7 @@ namespace Eco.Plugins.DiscordLink
                 {
                     foreach (ChannelLink link in DLConfig.GetChannelLinks(verifiedLinksOnly: false))
                     {
-                        channelLinks.Add(new ChannelLinkStatusV1
+                        channelLinks.Add(new DiscordLinkChannelStatusV1
                         {
                             Id = link.DiscordChannelId.ToString(),
                             Valid = link.IsValid()

--- a/DiscordLink/Source/WebApi/V1/DiscordLinkController.cs
+++ b/DiscordLink/Source/WebApi/V1/DiscordLinkController.cs
@@ -23,7 +23,7 @@ namespace Eco.Plugins.DiscordLink
         }
 
         /// <summary>Post an Invite to the discord server.</summary>
-        [HttpPost("/chat/invite")]
+        [HttpPost("chat/invite")]
         public async Task<bool> PostInviteMessage()
         {
             bool sent = await SharedCommands.PostInviteMessage(SharedCommands.CommandInterface.WebCommand, null);

--- a/DiscordLink/Source/WebApi/V1/Models/DiscordLinkChannelStatusV1.cs
+++ b/DiscordLink/Source/WebApi/V1/Models/DiscordLinkChannelStatusV1.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DiscordLink.Source.WebApi.V1.Models
+﻿namespace DiscordLink.Source.WebApi.V1.Models
 {
     public class DiscordLinkChannelStatusV1
     {

--- a/DiscordLink/Source/WebApi/V1/Models/DiscordLinkChannelStatusV1.cs
+++ b/DiscordLink/Source/WebApi/V1/Models/DiscordLinkChannelStatusV1.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DiscordLink.Source.WebApi.V1.Models
+{
+    public class DiscordLinkChannelStatusV1
+    {
+        public string Id;
+        public bool Valid;
+    }
+}

--- a/DiscordLink/Source/WebApi/V1/Models/DiscordLinkConfigStatusV1.cs
+++ b/DiscordLink/Source/WebApi/V1/Models/DiscordLinkConfigStatusV1.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace DiscordLink.Source.WebApi.V1.Models
+{
+    public class ChannelLinkStatusV1
+    {
+        public string Id;
+        public bool Valid;
+    }
+    public class DiscordLinkConfigStatusV1
+    {
+        public bool ClientConnected;
+        public bool ServerId;
+        public bool BotToken;
+        public bool InviteMessage;
+        public IEnumerable<ChannelLinkStatusV1> ChannelLinks;
+    }
+}

--- a/DiscordLink/Source/WebApi/V1/Models/DiscordLinkConfigStatusV1.cs
+++ b/DiscordLink/Source/WebApi/V1/Models/DiscordLinkConfigStatusV1.cs
@@ -2,17 +2,12 @@
 
 namespace DiscordLink.Source.WebApi.V1.Models
 {
-    public class ChannelLinkStatusV1
-    {
-        public string Id;
-        public bool Valid;
-    }
     public class DiscordLinkConfigStatusV1
     {
         public bool ClientConnected;
         public bool ServerId;
         public bool BotToken;
         public bool InviteMessage;
-        public IEnumerable<ChannelLinkStatusV1> ChannelLinks;
+        public IEnumerable<DiscordLinkChannelStatusV1> ChannelLinks;
     }
 }

--- a/DiscordLink/Source/WebApi/V1/Models/DiscordLinkPluginStatusV1.cs
+++ b/DiscordLink/Source/WebApi/V1/Models/DiscordLinkPluginStatusV1.cs
@@ -1,0 +1,14 @@
+﻿namespace DiscordLink.Source.WebApi.V1.Models
+{
+    public class DiscordLinkPluginStatusV1
+    {
+        public string DiscordStatus;
+        public string PluginStatus;
+        public string ServerVersion;
+        public string PluginVersion;
+        public int LinkedUsers;
+        public int OptInUsers;
+        public int OptOutUsers;
+        public string ClientName;
+    }
+}

--- a/DiscordLink/Source/WebApi/V1/Models/DiscordLinkPluginStatusV1.cs
+++ b/DiscordLink/Source/WebApi/V1/Models/DiscordLinkPluginStatusV1.cs
@@ -6,9 +6,6 @@
         public string PluginStatus;
         public string ServerVersion;
         public string PluginVersion;
-        public int LinkedUsers;
-        public int OptInUsers;
-        public int OptOutUsers;
         public string ClientName;
     }
 }


### PR DESCRIPTION
Adds basic functionality and documentation for DiscordLink to the AdminWebAPI. 
- Restarting the Plugin
- Config Validation
- View Plugin Status
- Posting Invites

All calls require the AdminAPIToken (Header `X-API-KEY`) else 401 response.

![image](https://user-images.githubusercontent.com/11261721/236603639-67cf7b77-e520-4f11-a06a-06a2fbc6690b.png)
