### PR TITLE
Logger-Wrapper to redirect all logs from DSharpPlus to MightyMooseCore

### DIFF
--- a/DiscordLink/Source/Core/DiscordClient.cs
+++ b/DiscordLink/Source/Core/DiscordClient.cs
@@ -116,6 +116,7 @@ namespace Eco.Plugins.DiscordLink
                     Token = DLConfig.Data.BotToken,
                     TokenType = TokenType.Bot,
                     MinimumLogLevel = DLConfig.Data.BackendLogLevel,
+                    LoggerFactory = new DSharpPlusLogWrapperFactory(DLConfig.Data.BackendLogLevel, DLConfig.Data.TraceFileLogging),
                     Intents = DLConstants.REQUESTED_INTENTS.Aggregate((current, next) => current | next)
                 });
 
@@ -829,7 +830,7 @@ namespace Eco.Plugins.DiscordLink
             }
             catch (UnauthorizedException e)
             {
-                Logger.Exception($"DiscordLink was not allowed to revoke the role \"{role.Name}\" from member \"{member.Username}\". Ensure that your bot user is assigned a role with higher permission level than all roles it manages.", e);
+                Logger.Exception($"DiscordLink was not allowed to revoke the role \"{role.Name}\" from member \"{member.Username}\". Ensure that your bot user is assigned a role with higher permission level than all roles it manages. This role was most likely not created by the current bot. Deleting it manually will resolve this Issue.", e);
             }
             catch (ServerErrorException e)
             {

--- a/DiscordLink/Source/Logging/DSharpPlusLogWrapper.cs
+++ b/DiscordLink/Source/Logging/DSharpPlusLogWrapper.cs
@@ -1,0 +1,82 @@
+using System;
+using Eco.Moose.Tools.Logger;
+using Microsoft.Extensions.Logging;
+using Nito.Disposables;
+
+namespace Eco.Plugins.DiscordLink;
+
+/**
+ * Implements the Microsoft Logging interface to call the MightyMoose Logger.
+ */
+public class DSharpPlusLogWrapper : ILogger
+{
+    private readonly LogLevel _minimumLevel;
+    private readonly bool _saveTraceToFile;
+
+    public DSharpPlusLogWrapper(LogLevel minLevel, bool saveTraceToFile)
+    {
+        _minimumLevel = minLevel;
+        _saveTraceToFile = saveTraceToFile;
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+        Func<TState, Exception, string> formatter)
+    {
+        var message = formatter(state, exception);
+        if (exception != null)
+        {
+            Console.WriteLine(exception);
+        }
+
+        if (message == null || !IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        var eventName = eventId.Name;
+        eventName = eventName?.Length > 12 ? eventName?.Substring(0, 12) : eventName;
+        var msgPrefix = $"[/{eventName,-12}]";
+
+        switch (logLevel)
+        {
+            case LogLevel.Trace:
+                Logger.Trace($"{msgPrefix} {message}");
+
+                if (_saveTraceToFile)
+                    Logger.Silent($"{msgPrefix} {message}");
+                break;
+            case LogLevel.Debug:
+                Logger.Debug($"{msgPrefix} {message}");
+                break;
+            case LogLevel.Information:
+                Logger.Info($"{msgPrefix} {message}");
+                break;
+            case LogLevel.Warning:
+                Logger.Warning($"{msgPrefix} {message}");
+                break;
+            case LogLevel.Error:
+                Logger.Error($"{msgPrefix} {message}");
+                break;
+            case LogLevel.Critical:
+                Logger.Error($"{msgPrefix} {message}");
+                break;
+            case LogLevel.None:
+                break;
+
+            default:
+                Logger.Info($"{msgPrefix} {message}");
+                break;
+        }
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+        => logLevel >= _minimumLevel;
+
+    /**
+     * Nothing to dispose
+     */
+    public IDisposable BeginScope<TState>(TState state)
+    {
+        return new Disposable(null);
+    }
+}

--- a/DiscordLink/Source/Logging/DSharpPlusLogWrapperFactory.cs
+++ b/DiscordLink/Source/Logging/DSharpPlusLogWrapperFactory.cs
@@ -1,0 +1,35 @@
+using Eco.Moose.Tools.Logger;
+using Microsoft.Extensions.Logging;
+
+namespace Eco.Plugins.DiscordLink;
+
+/**
+ * Factory Class for Loggers, which redirect their Output to the MightyMoose Implementation. This will also save Trace-Logs to File when enabled.
+ */
+public class DSharpPlusLogWrapperFactory : ILoggerFactory
+{
+    private readonly bool _saveTraceToFile;
+    private LogLevel MinimumLevel { get; }
+
+    public DSharpPlusLogWrapperFactory(LogLevel minimumLevel, bool saveTraceToFile)
+    {
+        _saveTraceToFile = saveTraceToFile;
+        MinimumLevel = minimumLevel;
+    }
+
+    public void Dispose()
+    {
+       // Nothing to dispose
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new DSharpPlusLogWrapper(MinimumLevel, _saveTraceToFile);
+    }
+
+    public void AddProvider(ILoggerProvider provider)
+    {
+        // we don't really need that for our simple use case
+        Logger.Warning("Tried to add a Log-Provider, which is not Supported right now.");
+    }
+}

--- a/DiscordLink/Source/Systems/Config.cs
+++ b/DiscordLink/Source/Systems/Config.cs
@@ -385,6 +385,9 @@ namespace Eco.Plugins.DiscordLink
 
         [Description("Determines what backend message types will be printed to the server log. All message types below the selected one will be printed as well. This setting requires a plugin restart to take effect."), Category("Plugin Configuration")]
         public Microsoft.Extensions.Logging.LogLevel BackendLogLevel { get; set; } = DLConfig.DefaultValues.BackendLogLevel;
+        
+        [Description("Trace-Logs are not logged to file by default. Please only enable this to diagnose issues. Enabling this will save every single request made to the Discord API to the logfile. This will create huge logs over time. This setting requires a plugin restart to take effect."), Category("Plugin Configuration")]
+        public bool TraceFileLogging { get; set; } = false;
 
         [Description("Determines if the output in the display tab of the server GUI should be verbose or not. This setting can be changed while the server is running."), Category("Plugin Configuration")]
         public bool UseVerboseDisplay { get; set; } = DLConfig.DefaultValues.UseVerboseDisplay;


### PR DESCRIPTION
* dsharpplus logs are now written to the discordlink log-file
* trace-logging to file can optionally be enabled in config for issue diagnosis