### PR TITLE
Support forum channels and threads

### DIFF
--- a/DiscordLink/Source/Core/DiscordClient.cs
+++ b/DiscordLink/Source/Core/DiscordClient.cs
@@ -381,7 +381,7 @@ namespace Eco.Plugins.DiscordLink
 
         public DiscordChannel GetChannelById(ulong channelId)
         {
-            return Guild.Channels.Values.FirstOrDefault(channel => channel.Id == channelId);
+            return Guild.Channels.Values.FirstOrDefault(channel => channel.Id == channelId, Guild.Threads.Values.FirstOrDefault(channel => channel.Id == channelId));
         }
 
         public DiscordChannel GetChannelByName(string channelName)


### PR DESCRIPTION
If the provided ID doesn't resolve as a normal channel, search threads instead. The `Threads` collection contains regular threads and forum channels.

Fixes #94 